### PR TITLE
lavender:  correct rmt_storage service name

### DIFF
--- a/rootdir/etc/init.target.rc
+++ b/rootdir/etc/init.target.rc
@@ -87,7 +87,7 @@ on post-fs-data
     mkdir /data/tombstones/dsps 0771 system system
 
 on boot
-    start rmt_storage
+    start vendro.rmt_storage
     start rfs_access
     write /dev/cpuset/top-app/cpus 0-7
     write /dev/cpuset/foreground/cpus 0-7


### PR DESCRIPTION
rmt_storage service defined in /vendor/etc/init/vendor.qti.rmt_storage.rc as vendor.rmt_storage

inti: Commond 'start rmt_storage' action=boot (/vendor/etc/init/hw/init.target.er:90) took 0ms and failed: service rmt_storage not found